### PR TITLE
fix: change default image alias to ubuntu20

### DIFF
--- a/ionoscloud.go
+++ b/ionoscloud.go
@@ -38,7 +38,7 @@ const (
 
 const (
 	defaultRegion           = "us/las"
-	defaultImageAlias       = "ubuntu:latest"
+	defaultImageAlias       = "ubuntu:20.04"
 	defaultImagePassword    = "abcde12345" // Must contain both letters and numbers, at least 8 characters
 	defaultCpuFamily        = "AMD_OPTERON"
 	defaultAvailabilityZone = "AUTO"

--- a/ionoscloud_test.go
+++ b/ionoscloud_test.go
@@ -24,7 +24,7 @@ var (
 	testImageIdVar = "test-image-id"
 	locationId     = "las"
 	imageType      = "HDD"
-	imageName      = "ubuntu:latest"
+	imageName      = defaultImageAlias
 	imageLocation  = "us/las"
 	dcVersion      = int32(1)
 	testErr        = fmt.Errorf("error")


### PR DESCRIPTION
## What does this fix or implement?

id-rsa has been deprecated and SSH connectivity to a Docker host running ubuntu:22.04 isn't possible with the current version of Docker Machine Driver

