### PR TITLE
fix: user data not encoded when sshUser is root

### DIFF
--- a/ionoscloud.go
+++ b/ionoscloud.go
@@ -405,8 +405,9 @@ func (d *Driver) Create() error {
 			d.UserData = "#cloud-config\n" + d.UserData
 		}
 		newUserData, _ := d.addSSHUserToYaml()
-		d.UserData = b64.StdEncoding.EncodeToString([]byte(d.UserData + newUserData))
+		d.UserData += newUserData
 	}
+	d.UserData = b64.StdEncoding.EncodeToString([]byte(d.UserData))
 
 	result, err := d.getImageId(d.Image)
 	if err != nil {


### PR DESCRIPTION
## What does this fix or implement?

Fixed a bug with cloudinit not being b64 encoded when sshUser was root.
 
https://github.com/ionos-cloud/docker-machine-driver/commit/98ba02f0fd2a66ad6832ca247d700b2734907157#diff-b2fc63f71186d8be83709b49672180cb8de45fc2b4b4f4c7fdf36138b3b62142R389

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
