### PR TITLE
fix: duplicated cloud config users

### DIFF
--- a/internal/utils/client_service.go
+++ b/internal/utils/client_service.go
@@ -3,6 +3,7 @@ package utils
 import ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 
 type ClientService interface {
+	UpdateCloudInitFile(cloudInitYAML string, key string, value []interface{}) (string, error)
 	CreateIpBlock(size int32, location string) (*ionoscloud.IpBlock, error)
 	GetIpBlockIps(ipBlock *ionoscloud.IpBlock) (*[]string, error)
 	RemoveIpBlock(ipBlockId string) error

--- a/internal/utils/client_test.go
+++ b/internal/utils/client_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
@@ -238,39 +237,5 @@ func getTestClient() *Client {
 				},
 			}}),
 		ctx: context.TODO(),
-	}
-}
-
-func TestClient_UpdateCloudInitFile(t *testing.T) {
-	type fields struct {
-		APIClient *sdkgo.APIClient
-		ctx       context.Context
-	}
-	type args struct {
-		cloudInitYAML string
-		key           string
-		values        []interface{}
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    string
-		wantErr assert.ErrorAssertionFunc
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Client{
-				APIClient: tt.fields.APIClient,
-				ctx:       tt.fields.ctx,
-			}
-			got, err := c.UpdateCloudInitFile(tt.args.cloudInitYAML, tt.args.key, tt.args.values)
-			if !tt.wantErr(t, err, fmt.Sprintf("UpdateCloudInitFile(%v, %v, %v)", tt.args.cloudInitYAML, tt.args.key, tt.args.values)) {
-				return
-			}
-			assert.Equalf(t, tt.want, got, "UpdateCloudInitFile(%v, %v, %v)", tt.args.cloudInitYAML, tt.args.key, tt.args.values)
-		})
 	}
 }

--- a/internal/utils/mocks/ClientService.go
+++ b/internal/utils/mocks/ClientService.go
@@ -370,3 +370,18 @@ func (mr *MockClientServiceMockRecorder) StopServer(datacenterId, serverId inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopServer", reflect.TypeOf((*MockClientService)(nil).StopServer), datacenterId, serverId)
 }
+
+// UpdateCloudInitFile mocks base method.
+func (m *MockClientService) UpdateCloudInitFile(cloudInitYAML, key string, value []interface{}) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCloudInitFile", cloudInitYAML, key, value)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCloudInitFile indicates an expected call of UpdateCloudInitFile.
+func (mr *MockClientServiceMockRecorder) UpdateCloudInitFile(cloudInitYAML, key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCloudInitFile", reflect.TypeOf((*MockClientService)(nil).UpdateCloudInitFile), cloudInitYAML, key, value)
+}

--- a/ionoscloud.go
+++ b/ionoscloud.go
@@ -3,13 +3,10 @@ package ionoscloud
 import (
 	"context"
 	"encoding/base64"
-	b64 "encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
-
-	"gopkg.in/yaml.v2"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
@@ -335,39 +332,16 @@ func (d *Driver) PreCreateCheck() error {
 }
 
 func (d *Driver) addSSHUserToYaml() (string, error) {
-	var (
-		sshUser     = d.SSHUser
-		sshkey      = d.SSHKey
-		yamlcontent = d.UserData
-	)
-	cf := make(map[interface{}]interface{})
-	if err := yaml.Unmarshal([]byte(yamlcontent), &cf); err != nil {
-		return "", err
-	}
-
 	commonUser := map[interface{}]interface{}{
-		"name":                sshUser,
+		"name":                d.SSHUser,
 		"lock_passwd":         true,
 		"sudo":                "ALL=(ALL) NOPASSWD:ALL",
 		"create_groups":       false,
 		"no_user_group":       true,
-		"ssh_authorized_keys": []string{sshkey},
+		"ssh_authorized_keys": []string{d.SSHKey},
 	}
 
-	if val, ok := cf["users"]; ok {
-		u := val.([]interface{})
-		cf["users"] = append(u, commonUser)
-	} else {
-		users := make([]interface{}, 1)
-		users[0] = commonUser
-		cf["users"] = users
-	}
-
-	yaml, err := yaml.Marshal(cf)
-	if err != nil {
-		return "", err
-	}
-	return string(yaml), nil
+	return d.client().UpdateCloudInitFile(d.UserData, "users", []interface{}{commonUser})
 }
 
 func getPropertyWithFallback[T comparable](p1 T, p2 T, empty T) T {
@@ -390,24 +364,20 @@ func (d *Driver) Create() error {
 		log.Debugf("SSH Key generated in file: %v", d.publicSSHKeyPath())
 	}
 
-	rootSSHKey := d.SSHKey
-
 	givenB64Userdata, _ := base64.StdEncoding.DecodeString(d.UserDataB64)
-
-	if ud := getPropertyWithFallback(d.UserData, string(givenB64Userdata), ""); ud != "" {
-		log.Infof("Using user data: %s", ud)
+	if ud := getPropertyWithFallback(string(givenB64Userdata), d.UserData, ""); ud != "" {
+		// Provided B64 User Data has priority over UI provided User Data
 		d.UserData = ud
 	}
 
+	rootSSHKey := d.SSHKey
 	if d.SSHUser != "root" {
 		rootSSHKey = ""
-		if d.UserData == "" {
-			d.UserData = "#cloud-config\n" + d.UserData
+		d.UserData, err = d.addSSHUserToYaml()
+		if err != nil {
+			return err
 		}
-		newUserData, _ := d.addSSHUserToYaml()
-		d.UserData += newUserData
 	}
-	d.UserData = b64.StdEncoding.EncodeToString([]byte(d.UserData))
 
 	result, err := d.getImageId(d.Image)
 	if err != nil {
@@ -491,6 +461,8 @@ func (d *Driver) Create() error {
 		log.Debugf("Server ID: %v", d.ServerId)
 	}
 
+	ud := base64.StdEncoding.EncodeToString([]byte(d.UserData))
+	log.Infof("Using user data: %s", ud)
 	properties := utils.ClientVolumeProperties{
 		DiskType:      d.DiskType,
 		Name:          d.MachineName,
@@ -498,7 +470,7 @@ func (d *Driver) Create() error {
 		Zone:          d.VolumeAvailabilityZone,
 		SshKey:        rootSSHKey,
 		DiskSize:      float32(d.DiskSize),
-		UserData:      d.UserData,
+		UserData:      ud,
 	}
 
 	if !d.UseAlias {


### PR DESCRIPTION
## What does this fix or implement?

Provisioning with some cloud config that contained any users would result in duplicating the existing users, which resulted in the cloud config not being executed

