### PR TITLE
fix: sshkey len err

### DIFF
--- a/ionoscloud.go
+++ b/ionoscloud.go
@@ -475,9 +475,7 @@ func (d *Driver) Create() error {
 		d.UserData = ud
 	}
 
-	rootSSHKey := d.SSHKey
 	if d.SSHUser != "root" {
-		rootSSHKey = ""
 		d.UserData, err = d.addSSHUserToYaml()
 		if err != nil {
 			return err
@@ -562,7 +560,7 @@ func (d *Driver) Create() error {
 		Type:          &d.DiskType,
 		Name:          &d.MachineName,
 		ImagePassword: &d.ImagePassword,
-		SshKeys:       &[]string{rootSSHKey},
+		SshKeys:       &[]string{d.SSHKey},
 		UserData:      &ud,
 	}
 


### PR DESCRIPTION
## What does this fix or implement?

Error creating machine: Error in driver during machine creation: failed to create server due to error: [(root).entities.volumes.items.[0].properties.sshKeys] Invalid SSH key. Maximum allowed key size is 8K (8192 characters) and it can not be empty. Given ssh key length: 0 characters

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
