### PR TITLE
fix: use resume and suspend for cube server, vmState to get server state

### DIFF
--- a/internal/utils/client.go
+++ b/internal/utils/client.go
@@ -288,8 +288,24 @@ func (c *Client) StartServer(datacenterId, serverId string) error {
 	return nil
 }
 
+func (c *Client) ResumeServer(datacenterId, serverId string) error {
+	_, err := c.ServersApi.DatacentersServersResumePost(c.ctx, datacenterId, serverId).Execute()
+	if err != nil {
+		return sdk_utils.ShortenOpenApiErr(err)
+	}
+	return nil
+}
+
 func (c *Client) StopServer(datacenterId, serverId string) error {
 	_, err := c.ServersApi.DatacentersServersStopPost(c.ctx, datacenterId, serverId).Execute()
+	if err != nil {
+		return sdk_utils.ShortenOpenApiErr(err)
+	}
+	return nil
+}
+
+func (c *Client) SuspendServer(datacenterId, serverId string) error {
+	_, err := c.ServersApi.DatacentersServersSuspendPost(c.ctx, datacenterId, serverId).Execute()
 	if err != nil {
 		return sdk_utils.ShortenOpenApiErr(err)
 	}

--- a/internal/utils/client_service.go
+++ b/internal/utils/client_service.go
@@ -26,7 +26,9 @@ type ClientService interface {
 	GetNic(datacenterId, ServerId, NicId string) (*ionoscloud.Nic, error)
 	GetTemplates() (*ionoscloud.Templates, error)
 	StartServer(datacenterId, serverId string) error
+	ResumeServer(datacenterId, serverId string) error
 	StopServer(datacenterId, serverId string) error
+	SuspendServer(datacenterId, serverId string) error
 	RestartServer(datacenterId, serverId string) error
 	RemoveServer(datacenterId, serverId string) error
 	CreateAttachVolume(datacenterId, serverId string, properties *ClientVolumeProperties) (*ionoscloud.Volume, error)

--- a/internal/utils/mocks/ClientService.go
+++ b/internal/utils/mocks/ClientService.go
@@ -447,6 +447,20 @@ func (mr *MockClientServiceMockRecorder) RestartServer(datacenterId, serverId in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestartServer", reflect.TypeOf((*MockClientService)(nil).RestartServer), datacenterId, serverId)
 }
 
+// ResumeServer mocks base method.
+func (m *MockClientService) ResumeServer(datacenterId, serverId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResumeServer", datacenterId, serverId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResumeServer indicates an expected call of ResumeServer.
+func (mr *MockClientServiceMockRecorder) ResumeServer(datacenterId, serverId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeServer", reflect.TypeOf((*MockClientService)(nil).ResumeServer), datacenterId, serverId)
+}
+
 // StartServer mocks base method.
 func (m *MockClientService) StartServer(datacenterId, serverId string) error {
 	m.ctrl.T.Helper()
@@ -473,6 +487,20 @@ func (m *MockClientService) StopServer(datacenterId, serverId string) error {
 func (mr *MockClientServiceMockRecorder) StopServer(datacenterId, serverId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopServer", reflect.TypeOf((*MockClientService)(nil).StopServer), datacenterId, serverId)
+}
+
+// SuspendServer mocks base method.
+func (m *MockClientService) SuspendServer(datacenterId, serverId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SuspendServer", datacenterId, serverId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SuspendServer indicates an expected call of SuspendServer.
+func (mr *MockClientServiceMockRecorder) SuspendServer(datacenterId, serverId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuspendServer", reflect.TypeOf((*MockClientService)(nil).SuspendServer), datacenterId, serverId)
 }
 
 // UpdateCloudInitFile mocks base method.

--- a/ionoscloud_test.go
+++ b/ionoscloud_test.go
@@ -806,7 +806,7 @@ func TestStartServerErr(t *testing.T) {
 }
 
 func TestStartRunningServer(t *testing.T) {
-	s := serverWithState(testVar, "AVAILABLE")
+	s := serverWithState(testVar, "RUNNING")
 	driver, clientMock := NewTestDriverFlagsSet(t, authFlagsSet)
 	driver.DatacenterId = testVar
 	driver.ServerId = testVar
@@ -826,7 +826,7 @@ func TestStopErr(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	s := serverWithState(testVar, "NOSTATE")
+	s := serverWithState(testVar, "SHUTOFF")
 	driver, clientMock := NewTestDriverFlagsSet(t, authFlagsSet)
 	driver.DatacenterId = testVar
 	driver.ServerId = testVar
@@ -1005,8 +1005,8 @@ func TestGetImageId(t *testing.T) {
 func serverWithState(serverId, serverState string) *sdkgo.Server {
 	return &sdkgo.Server{
 		Id: &serverId,
-		Metadata: &sdkgo.DatacenterElementMetadata{
-			State: &serverState,
+		Properties: &sdkgo.ServerProperties{
+			VmState: &serverState,
 		},
 	}
 }
@@ -1014,8 +1014,8 @@ func serverWithState(serverId, serverState string) *sdkgo.Server {
 func serverWithNicAttached(serverId, serverState, nicId string) *sdkgo.Server {
 	return &sdkgo.Server{
 		Id: &serverId,
-		Metadata: &sdkgo.DatacenterElementMetadata{
-			State: &serverState,
+		Properties: &sdkgo.ServerProperties{
+			VmState: &serverState,
 		},
 		Entities: &sdkgo.ServerEntities{
 			Nics: &sdkgo.Nics{


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
