### PR TITLE
fix #95: rm info log 'using IP x.x.x.x to connect'

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## \[7.0.1]
+### Changed
+* changed:
+  * removed debug info log for `GetIP`: "Using IP x.x.x.x to connect"
+  
+## \[7.0.0]
+
+### Changed
+* renamed:
+  * `user-data` to `cloud-init`
+  * `user-data-b64` to `cloud-init-b64`
+  * `ssh-in-user-data` to `ssh-in-cloud-init`
+
+### Fixed
+* fixed:
+  * driver ip not being set if it was private
+  * ipblock delete request was sent even if no ipblock existed
+  * start and stop not working for CUBE servers
+
 ## \[7.0.0-rc.2\]
 ### Changed
 * fixed:

--- a/ionoscloud.go
+++ b/ionoscloud.go
@@ -184,7 +184,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			Name:   flagNatId,
 			EnvVar: extflag.KebabCaseToEnvVarCase(flagNatId),
-			//Value:  nil,
+			// Value:  nil,
 			Usage: "Ionos Cloud existing and configured NAT Gateway",
 		},
 		mcnflag.BoolFlag{
@@ -1017,7 +1017,6 @@ func (d *Driver) GetIP() (string, error) {
 	if d.IPAddress == "" {
 		return "", fmt.Errorf("IP address is not set")
 	}
-	log.Infof("Using IP %s to connect", d.IPAddress)
 	return d.IPAddress, nil
 }
 


### PR DESCRIPTION
This PR removes this logging print for `GetIP`