### PR TITLE
feat: Append rke provisioning to userdata

### DIFF
--- a/ionos_create_machine_test.go
+++ b/ionos_create_machine_test.go
@@ -1,0 +1,71 @@
+package ionoscloud
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/ionos-cloud/docker-machine-driver/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// This is an integration test to verify that the final user data is correctly generated when using RKE provisioning.
+// It ensures that the RKE provisioning script is correctly appended to the user data.
+// rancher-machine creates a temp file and sets the path into flag, therefore we also have to create a temp file here
+func TestGetFinalUserDataWithRKEProvision(t *testing.T) {
+	driver, _ := NewTestDriver(t, "test-host", "defaultstore")
+	driver.SSHUser = "root"
+	driver.client = func() utils.ClientService {
+		return utils.New(context.TODO(), driver.Username, driver.Password, driver.Token, driver.Endpoint, "user-agent")
+	}
+	driver.CloudInit = `#cloud-config
+hostname: test.example.com
+packages:
+  - somepackage
+runcmd:
+- sh user_script.sh
+write_files:
+- path: /etc/user_script.sh
+  content: some user content
+`
+	tmpFile, err := os.CreateTemp("", "rke-provision-*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	rkeContent := `#cloud-config
+runcmd:
+- sh /etc/rke.sh
+write_files:
+- path: /etc/rke.sh
+  content: some install content
+`
+	if _, err := tmpFile.WriteString(rkeContent); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
+
+	driver.RKEProvisionUserData = tmpFile.Name()
+
+	expectedResult := `#cloud-config
+hostname: test.example.com
+packages:
+    - somepackage
+runcmd:
+    - sh user_script.sh
+    - sh /etc/rke.sh
+write_files:
+    - content: some user content
+      path: /etc/user_script.sh
+    - content: some install content
+      path: /etc/rke.sh
+`
+	result, err := driver.GetFinalUserData()
+	assert.NoError(t, err)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte(expectedResult)), result)
+}


### PR DESCRIPTION
## What does this fix or implement?

When RKE2 cluster with node drivers is created via Rancher Management cluster, rancher expects driver to have a flag with cloud-init path (matching specific flag name). If a file exists at that path, rancher tries to merge in RKE install commands, if it does not it creates a new cloud init and sets the path into that flag. This functionality ensures each new node joins the cluster. 

Existing `cloud-init` and `cloud-init-b64` flags dont match ranchers expected flag format *and* they contain contents rather than file path. Additionally there is a bunch of operations done with those contents so adapting them to what rancher expects didnt make sense. Therefore a new flag, which fits ranchers expectations, was introduced. When rancher populates it, it's contents get merged into existing cloud init.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [x] Tests added or updated
- [ ] Documentation updated
        Not sure which part of the documentation to update, please advise. This functionality kinda fits under `Option 1` but it wasnt operational.
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
