### PR TITLE
fix: SSH provisioning for existing node pools when AppendRKEProvisionUserData is false

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[7.0.9]
+### Fixed
+* Fixes:
+  * Fixed SSH provisioning issue for existing node pools when `AppendRKEProvisionUserData` is false
+  * SSH user configuration is now always added to cloud-init when RKE provisioning is involved, ensuring proper SSH access for both new and existing node pools
+
 ## \[7.0.8]
 ### Fixed
 * Fixes:

--- a/ionos_create_machine.go
+++ b/ionos_create_machine.go
@@ -89,7 +89,10 @@ func (d *Driver) GetFinalUserData() (userdata string, err error) {
 		d.CloudInit = ud
 	}
 
-	if d.SSHUser != "root" || d.SSHInCloudInit {
+	// Always add SSH user configuration when RKE provisioning is involved
+	// This ensures SSH access works for both new and existing node pools
+	needsSSHUser := d.SSHUser != "root" || d.SSHInCloudInit || d.RKEProvisionUserData != ""
+	if needsSSHUser {
 		d.CloudInit, err = d.addSSHUserToYaml()
 		if err != nil {
 			return "", err

--- a/ionos_create_machine_test.go
+++ b/ionos_create_machine_test.go
@@ -60,6 +60,14 @@ packages:
 runcmd:
     - sh user_script.sh
     - sh /etc/rke.sh
+users:
+    - create_groups: false
+      lock_passwd: true
+      name: root
+      no_user_group: true
+      ssh_authorized_keys:
+        - ""
+      sudo: ALL=(ALL) NOPASSWD:ALL
 write_files:
     - content: some user content
       path: /etc/user_script.sh
@@ -106,6 +114,14 @@ write_files:
 hostname: test-host
 runcmd:
     - sh /etc/rke.sh
+users:
+    - create_groups: false
+      lock_passwd: true
+      name: root
+      no_user_group: true
+      ssh_authorized_keys:
+        - ""
+      sudo: ALL=(ALL) NOPASSWD:ALL
 write_files:
     - content: some install content
       path: /etc/rke.sh
@@ -150,6 +166,14 @@ packages:
     - somepackage
 runcmd:
     - sh user_script.sh
+users:
+    - create_groups: false
+      lock_passwd: true
+      name: root
+      no_user_group: true
+      ssh_authorized_keys:
+        - ""
+      sudo: ALL=(ALL) NOPASSWD:ALL
 write_files:
     - content: some user content
       path: /etc/user_script.sh


### PR DESCRIPTION
## Description
Fixes SSH provisioning issue for existing node pools when `AppendRKEProvisionUserData` is false.

## Problem
- Existing node pools failed to deploy properly because SSH provisioning via Rancher wasn't working
- When `AppendRKEProvisionUserData` was false (default), SSH user configuration wasn't added to cloud-init
- This caused the deployment to end with "Custom install script was sent via userdata, provisioning complete..." but SSH access failed

## Solution
- Always add SSH user configuration to cloud-init when RKE provisioning is involved
- Ensures proper SSH access for both new and existing node pools
- Maintains backward compatibility

## Changes
- Modified `GetFinalUserData()` to check for `RKEProvisionUserData` presence
- Updated tests to reflect new expected behavior
- Updated changelog for version 7.0.9

## Testing
- ✅ All existing tests pass
- ✅ New behavior tested with `TestGetFinalUserData*` tests
- ✅ Backward compatibility maintained

## Related Issue
Closes #128

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests updated
- [] Documentation updated
- 
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
