### PR TITLE
fix: replace deprecated io/ioutil and fix typo in error message

### DIFF
--- a/ionoscloud.go
+++ b/ionoscloud.go
@@ -3,7 +3,7 @@ package ionoscloud
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -860,7 +860,7 @@ func (d *Driver) Stop() error {
 		err = fmt.Errorf("wrong server type: %s", d.ServerType)
 	}
 	if err != nil {
-		return fmt.Errorf("error stoping server: %w", err)
+		return fmt.Errorf("error stopping server: %w", err)
 	}
 	return nil
 }
@@ -959,7 +959,7 @@ func (d *Driver) createSSHKey() (string, error) {
 	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return "", err
 	}
-	publicKey, err := ioutil.ReadFile(d.publicSSHKeyPath())
+	publicKey, err := os.ReadFile(d.publicSSHKeyPath())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Replace io/ioutil.ReadFile with os.ReadFile (ioutil deprecated since Go 1.16, this project uses Go 1.25)
- Fix typo "stoping" -> "stopping" in Stop() error message

## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Sonar Cloud Scan
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated
